### PR TITLE
Modify image name

### DIFF
--- a/.github/workflows/dev-push-sakura-registry.yaml
+++ b/.github/workflows/dev-push-sakura-registry.yaml
@@ -22,7 +22,7 @@ jobs:
         uses: docker/metadata-action@v4
         id: image-tag
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
           tags: |
             type=raw,prefix=dev-,value=latest
             type=sha,prefix=dev-,format=short

--- a/.github/workflows/mgmt-push-sakura-registry.yaml
+++ b/.github/workflows/mgmt-push-sakura-registry.yaml
@@ -22,7 +22,7 @@ jobs:
         uses: docker/metadata-action@v4
         id: image-tag
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
           tags: |
             type=raw,prefix=mgmt-,value=latest
             type=sha,prefix=mgmt-,format=short

--- a/.github/workflows/push-sakura-registry.yaml
+++ b/.github/workflows/push-sakura-registry.yaml
@@ -22,7 +22,7 @@ jobs:
         uses: docker/metadata-action@v4
         id: image-tag
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
           tags: |
             type=raw,value=latest
             type=sha,prefix=,format=short


### PR DESCRIPTION
ghcr.ioへプッシュするイメージ名の修正

## 背景
- workflowにて、ghcr.ioへのイメージのプッシュに失敗していた
- イメージ名にオーナーが含まれていないことが原因と考えられる