### PR TITLE
解答のマークダウン表示

### DIFF
--- a/pages/problems/[problemId].tsx
+++ b/pages/problems/[problemId].tsx
@@ -453,7 +453,7 @@ const AnswerListSection = ({ problem }: AnswerSectionProps) => {
               {isPreviewAnswer ? (
                 <MarkdownPreview content={selectedAnswer.body} />
               ) : (
-                <textarea className="textarea textarea-bordered mt-4 px-2 min-h-[300px]">
+                <textarea readOnly className="textarea textarea-bordered mt-4 px-2 min-h-[300px]">
                   {selectedAnswer.body}
                 </textarea>
               )}

--- a/pages/problems/[problemId].tsx
+++ b/pages/problems/[problemId].tsx
@@ -11,6 +11,7 @@ import ICTSCNavBar from "../../components/Navbar";
 import ICTSCCard from "../../components/Card";
 import { ICTSCErrorAlert, ICTSCSuccessAlert } from "../../components/Alerts";
 import MarkdownPreview from "../../components/MarkdownPreview";
+import MarkdownRawPreview from "../../components/MarkdownRawPreview";
 import LoadingPage from "../../components/LoadingPage";
 import { useApi } from "../../hooks/api";
 import { useAuth } from "../../hooks/auth";
@@ -282,7 +283,7 @@ const ProblemPage = () => {
                   onClick={() => setIsPreview(false)}
                   className={`tab tab-lifted ${!isPreview && "tab-active"}`}
                 >
-                  Write
+                  Markdown
                 </a>
                 <a
                   onClick={() => setIsPreview(true)}
@@ -356,6 +357,7 @@ const AnswerListSection = ({ problem }: AnswerSectionProps) => {
   const [selectedAnswerId, setSelectedAnswerId] = useState<string | null>(null);
   const { answers, getAnswer, mutate } = useAnswers(problem?.id as string);
   const selectedAnswer = getAnswer(selectedAnswerId as string);
+  const [isPreviewAnswer, setIsPreviewAnswer] = useState(true);
 
   return (
     <>
@@ -443,7 +445,19 @@ const AnswerListSection = ({ problem }: AnswerSectionProps) => {
                 )}
               </div>
             </div>
-            <MarkdownPreview content={selectedAnswer.body} />
+            <div className="flex flex-col">
+              <div className="tabs">
+                <a onClick={() => setIsPreviewAnswer(false)} className={`tab tab-lifted ${!isPreviewAnswer && "tab-active"}`}>Markdown</a>
+                <a onClick={() => setIsPreviewAnswer(true)} className={`tab tab-lifted ${isPreviewAnswer && "tab-active"}`}>Preview</a>
+              </div>
+              {isPreviewAnswer ? (
+                <MarkdownPreview content={selectedAnswer.body} />
+              ) : (
+                <textarea className="textarea textarea-bordered mt-4 px-2 min-h-[300px]">
+                  {selectedAnswer.body}
+                </textarea>
+              )}
+            </div>
           </ICTSCCard>
         </div>
       )}


### PR DESCRIPTION
解答フォームだけではなく、解答表示の部分でもマークダウン表記とプレビュー表記を選べるようにした。

<img width="1268" alt="スクリーンショット 2023-03-07 15 02 46" src="https://user-images.githubusercontent.com/14256420/223334580-1319a728-f548-4a77-9e5d-c708b107eee5.png">
