### PR TITLE
fix: ランキングページに遷移してうまく取得できない場合に 404 になる問題を修正 / update: vitest のオプションに …

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "test": "vitest --coverage",
+    "test": "vitest --run --coverage",
     "test:e2e": "playwright test",
     "test:e2e-ui": "playwright test --ui",
     "lint": "next lint",

--- a/pages/ranking.tsx
+++ b/pages/ranking.tsx
@@ -1,5 +1,3 @@
-import Error from "next/error";
-
 import LoadingPage from "@/components/LoadingPage";
 import useRanking from "@/hooks/ranking";
 import CommonLayout from "@/layouts/CommonLayout";
@@ -13,10 +11,6 @@ function Ranking() {
         <LoadingPage />
       </CommonLayout>
     );
-  }
-
-  if (ranking === null) {
-    return <Error statusCode={404} />;
   }
 
   return (


### PR DESCRIPTION
## 主な変更

* fix: ランキングページに遷移してうまく取得できない場合に 404 になる問題を修正
* update: vitest のオプションに --run を追加